### PR TITLE
Add and document purgeCssEnabled option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const glob = require('glob-all')
 const PurgecssPlugin = require('purgecss-webpack-plugin')
 
 module.exports = ({
+  purgeCssEnabled = ({ dev, isServer }) => (!dev && !isServer),
   purgeCss = {},
   purgeCssPaths = ['pages/**/*', 'components/**/*'],
   webpack,
@@ -12,7 +13,12 @@ module.exports = ({
   ...nextConfig,
 
   // overwrite webpack config
-  webpack: (webpackConfig, options) => {
+  webpack: (webpackConfig, { dev, isServer }) => {
+    // Don't add plugin unless PurgeCSS is enabled
+    if (!purgeCssEnabled({ dev, isServer })) {
+      return webpackConfig
+    }
+
     webpackConfig.plugins.push(
       new PurgecssPlugin({
         paths: () =>

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const glob = require('glob-all')
 const PurgecssPlugin = require('purgecss-webpack-plugin')
 
 module.exports = ({
-  purgeCssEnabled = ({ dev, isServer }) => true,
+  purgeCssEnabled = () => true,
   purgeCss = {},
   purgeCssPaths = ['pages/**/*', 'components/**/*'],
   webpack,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const glob = require('glob-all')
 const PurgecssPlugin = require('purgecss-webpack-plugin')
 
 module.exports = ({
-  purgeCssEnabled = ({ dev, isServer }) => (!dev && !isServer),
+  purgeCssEnabled = ({ dev, isServer }) => true,
   purgeCss = {},
   purgeCssPaths = ['pages/**/*', 'components/**/*'],
   webpack,

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ By default, `next-purgecss` will always remove unused CSS, regardless of build e
 | Argument | Type | Description |
 | --- | --- | --- |
 | `dev` | `Boolean` | `true` in development mode (running `next`) or `false` in production mode (running `next start`) |
-| `isServer` | `Boolean` | Shows if the configuration will be used for server side compilation (`true`), or client side compilation (`false`) |
+| `isServer` | `Boolean` | `true` during server side compilation or `false` during client side compilation |
 
 ```js
 // next.config.js

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,24 @@ module.exports = withCss(withPurgeCss())
 
 ## Options
 
+### `purgeCssEnabled`
+
+By default, `next-purgecss` will only remove unused CSS from client side production builds. You can change that by defining a function for the `purgeCssEnabled` option. The `purgeCssEnabled` function receives two arguments:
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `dev` | `Boolean` | Shows if the compilation is done in development mode (`true`) or production mode (`false`) |
+| `isServer` | `Boolean` | Shows if the configuration will be used for server side compilation (`true`), or client side compilation (`false`) |
+
+```js
+// next.config.js
+module.exports = withCss(
+  withPurgeCss({
+    purgeCssEnabled: ({ dev, isServer }) => true // Always enable PurgeCSS
+  })
+)
+```
+
 ### `purgeCssPaths`
 
 By default, this plugin will scan `components` and `pages`

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ By default, `next-purgecss` will always remove unused CSS, regardless of build e
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `dev` | `Boolean` | Shows if the compilation is done in development mode (`true`) or production mode (`false`) |
+| `dev` | `Boolean` | `true` in development mode (running `next`) or `false` in production mode (running `next start`) |
 | `isServer` | `Boolean` | Shows if the configuration will be used for server side compilation (`true`), or client side compilation (`false`) |
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ module.exports = withCss(withPurgeCss())
 
 ### `purgeCssEnabled`
 
-By default, `next-purgecss` will only remove unused CSS from client side production builds. You can change that by defining a function for the `purgeCssEnabled` option. The `purgeCssEnabled` function receives two arguments:
+By default, `next-purgecss` will always remove unused CSS, regardless of build environment. You can change that by defining a function for the `purgeCssEnabled` option. The `purgeCssEnabled` function receives two arguments:
 
 | Argument | Type | Description |
 | --- | --- | --- |
@@ -57,7 +57,7 @@ By default, `next-purgecss` will only remove unused CSS from client side product
 // next.config.js
 module.exports = withCss(
   withPurgeCss({
-    purgeCssEnabled: ({ dev, isServer }) => true // Always enable PurgeCSS
+    purgeCssEnabled: ({ dev, isServer }) => (!isDev && !isServer) // Only enable PurgeCSS for client-side production builds
   })
 )
 ```


### PR DESCRIPTION
Adds `purgeCssEnabled`, a new option that allows you to control whether or not PurgeCSS is enabled based on build environment (development/production and server-side/client-side). Inspired by the `enabled` option from [nuxt-purgecss](https://github.com/Developmint/nuxt-purgecss#enabled).

Super useful for developers who design in the browser using atomic CSS frameworks like [Tailwind](http://tailwindcss.com/), and therefore need all CSS classes available in the development build.

`nuxt-purgecss` actually disables PurgeCSS for dev and server environments by default, which is my preference, but I wrote this pull request to keep PurgeCSS enabled by default so that this isn't a breaking change.