### PR TITLE
Modify branching logic around purgeCssEnabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,24 +14,23 @@ module.exports = ({
 
   // overwrite webpack config
   webpack: (webpackConfig, options) => {
-    // Don't add plugin unless PurgeCSS is enabled
     const { dev, isServer } = options
-    if (!purgeCssEnabled({ dev, isServer })) {
-      return webpackConfig
-    }
 
-    webpackConfig.plugins.push(
-      new PurgecssPlugin({
-        paths: () =>
-          glob.sync(
-            purgeCssPaths.map(p => path.join(webpackConfig.context, p)),
-            {
-              nodir: true
-            }
-          ),
-        ...purgeCss
-      })
-    )
+    // Only add plugin when PurgeCSS is enabled
+    if (purgeCssEnabled({ dev, isServer })) {
+      webpackConfig.plugins.push(
+        new PurgecssPlugin({
+          paths: () =>
+            glob.sync(
+              purgeCssPaths.map(p => path.join(webpackConfig.context, p)),
+              {
+                nodir: true
+              }
+            ),
+          ...purgeCss
+        })
+      )
+    }
 
     if (typeof webpack === 'function') {
       return webpack(webpackConfig, options)


### PR DESCRIPTION
This switches the behavior from returning early when PurgeCSS is disabled to instead wrap the addition of `purgecss-webpack-plugin` in the check for `purgeCssEnabled` returning true. This ensures the Webpack config is always properly passed through any custom `webpack` function in the Next.js config.